### PR TITLE
Fix pkg-config Cflags

### DIFF
--- a/chardet.pc.in
+++ b/chardet.pc.in
@@ -9,4 +9,4 @@ Name: @PACKAGE_NAME@
 Description: Mozilla's Universal Charset Detector C/C++ API
 Version: @PACKAGE_VERSION@
 Libs: -L${libdir} -lchardet
-Cflags: -I${includedir}/chardet @CFLAGS@
+Cflags: -I${includedir}/chardet


### PR DESCRIPTION
There currently is an issue with the pkg-config file included with the library in that its cflags field includes the autoconf CFLAGS variable. This may seem like a fairly natural thing to do at first sight, however it is in fact problematic because the autoconf CFLAGS variable and the pkg-config Cflags field serve different purposes: whereas the former specifies the flags used for building libchardet itself, [the latter specifies the flags needed for *using* the library](https://people.freedesktop.org/~dbn/pkg-config-guide.html#writing). Thus, the current setup causes flags used for building libchardet itself to leak into the build systems of dependent software packages where they can lead to build issues. In particular, the `-fvisibility=hidden` flag used for building libchardet can cause linker errors à la <code>hidden symbol \`foo' in bar.o is referenced by DSO</code> or <code>undefined reference to \`baz\`</code> in dependent software. Moreover, autoconf allows users to customise its CFLAGS variable at configure time, so not only do the flags specified by libchardet itself leak into dependent packages, but those specified by users as well. This is an issue with distributions packaging libchardet, since Linux distributions often extensively customise the default build flags for their official packages. For example, the pkg-config Cflags field in the Arch Linux package of libchardet currently looks like this:

    Cflags: -I${includedir}/chardet -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions         -Wp,-D_FORTIFY_SOURCE=3 -Wformat -Werror=format-security         -fstack-clash-protection -fcf-protection         -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -g -ffile-prefix-map=/build/libchardet/src=/usr/src/debug/libchardet -flto=auto -fvisibility=hidden

In openSUSE, it looks like this:

    Cflags: -I${includedir}/chardet -O2 -Wall -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -fstack-protector-strong -funwind-tables -fasynchronous-unwind-tables -fstack-clash-protection -Werror=return-type -flto=auto -g -fvisibility=hidden

This, too, leads to problems, for example because both of these distributions enable link time optimisation by default. However, software that uses libchardet may not support LTO, in which case build errors will follow. For instance, Cyrus IMAP, which uses libchardet, [does not support building with link time opimisation](https://www.cyrusimap.org/imap/developer/compiling.html). However if libchardet is built with lto enabled, as seen above, the `-flto=auto` flag will inadvertently be picked up by Cyrus’ build system via pkg-config even when LTO is otherwise disabled and cause the software to be built incorrectly.

Because of these problems, others are already working around this issue in their own way. Several major Linux distributions such as Debian and Fedora are removing the autoconf CFLAGS from the pkg-config file via downstream patches (see [here](https://salsa.debian.org/debian/libchardet/-/blob/master/debian/patches/fix-pkgconfig.patch) and [here](https://src.fedoraproject.org/rpms/libchardet/blob/main/f/libchardet-1.0.4-pc.in.patch)). However, I believe this should really be addressed upstream in libchardet itself.